### PR TITLE
Add restrictAccess composers to composer.ejs

### DIFF
--- a/generators/app/templates/composer.ejs
+++ b/generators/app/templates/composer.ejs
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { merge, composeWithTracker } from '/imports/client/compose';
 // import { NotAuthorizedError } from '/imports/errors';
+// import { restrictAccess } from '/imports/client/composers';
 
 const composer = (props, onData) => {
 //   if (!somethingHappens) {
@@ -14,4 +15,5 @@ const composer = (props, onData) => {
 
 export default merge(
   composeWithTracker(composer),
+  // restrictAccess,
 );


### PR DESCRIPTION
I was thinking instead of using NotAuthorizedError, we could use restrictAccess directly! .. maybe still leave the error as a reference